### PR TITLE
shallow-clone dependencies and avoid using git reset --hard

### DIFF
--- a/src/external/bulletphysics/commands.lua
+++ b/src/external/bulletphysics/commands.lua
@@ -9,15 +9,14 @@ end
 
 function clone()
     if not os.isdir(getdir() .. "/.git") then
-        os.execute("git clone " .. repo .. " " .. getdir())
+        os.execute("git clone --single-branch --branch master " .. repo .. " " .. getdir())
     end
     local success, msg, errno = os.chdir(dir)
     if not success then
         error(msg)
     end
-    os.execute("git reset --hard")
-    os.execute("git fetch origin master")
     os.execute("git checkout " .. current_rev)
+    os.execute("git clean -ffdx .")
     os.execute("git apply --ignore-whitespace ../bullet_build.patch")
 end
 

--- a/src/external/glm/commands.lua
+++ b/src/external/glm/commands.lua
@@ -1,5 +1,6 @@
 
 local repo = "https://github.com/g-truc/glm.git"
+local branch = "0.9.8-align"
 local dir = path.getbasename(repo)
 
 function getdir()
@@ -8,15 +9,14 @@ end
 
 function clone()
     if not os.isdir(getdir() .. "/.git") then
-        os.execute("git clone " .. repo .. " " .. getdir())
+        os.execute("git clone --depth 1 --branch " .. branch .. " " .. repo .. " " .. getdir())
     end
     local success, msg, errno = os.chdir(dir)
     if not success then
         error(msg)
     end
-    os.execute("git reset --hard")
-    os.execute("git fetch origin 0.9.8-align")
-    os.execute("git checkout 0.9.8-align")
+    os.execute("git checkout -- .")
+    os.execute("git clean -ffdx .")
 end
 
 function buildLinux()

--- a/src/external/sdl/commands.lua
+++ b/src/external/sdl/commands.lua
@@ -1,5 +1,6 @@
 
 local repo = "https://github.com/spurious/SDL-mirror.git"
+local branch = "release-2.0.4"
 local dir = "SDL"
 
 function getdir()
@@ -8,15 +9,14 @@ end
 
 function clone()
     if not os.isdir(getdir() .. "/.git") then
-        os.execute("git clone " .. repo .. " " .. getdir())
+        os.execute("git clone --depth 1 --branch " .. branch .. " " .. repo .. " " .. getdir())
     end
     local success, msg, errno = os.chdir(dir)
     if not success then
         error(msg)
     end
-    os.execute("git reset --hard")
-    os.execute("git fetch origin release-2.0.4")
-    os.execute("git checkout release-2.0.4")
+    os.execute("git checkout -- .")
+    os.execute("git clean -ffdx .")
 end
 
 function buildLinux()


### PR DESCRIPTION
Shallow-cloning glm and sdl but not bullet because you can't shallow-clone a specific commit.

You can't `git reset --hard` a specific directory, so if something goes wrong with a subrepo, `git reset --hard` could possibly reset the entire `engine_test` project and cause people to lose their working changes.

`git checkout -- . && git clean -ffdx .` should accomplish what we want while being safer.